### PR TITLE
add service-to-signal blueprint documentation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@
 /build
 /docs/fleet-management
 /docs/companion-application
+/docs/service-to-signal
 /docs/ros-racer
 /docs/img
 

--- a/README.md
+++ b/README.md
@@ -37,11 +37,15 @@ The Eclipse SDV Blueprints project hosts a collection of blueprints that demonst
 Checkout the project and:
 ```sh
   cd blueprints-website
+  mkdir docs
   yarn install
   yarn start
-
+```
   OR:
-    npx docusaurus start
+```sh
+  cd blueprints-website
+  mkdir docs
+  npx docusaurus start
 ```
 <br>
 

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -65,7 +65,7 @@ const config = {
         documents: ["seatadjuster-can.png", "seatadjuster.png", "create-release-tag.png", "action_general_workflow_permissions.png"],
         requestConfig: { responseType: "arraybuffer" }
       },
-  ],[
+  ], [
     "docusaurus-plugin-remote-content",
       {
           name: "fleet-management", 
@@ -81,6 +81,51 @@ const config = {
           outDir: "docs/img", // the base directory to output to.
           documents: ["architecture.drawio.svg"], // the file names to download
           requestConfig: { responseType: "arraybuffer" }
+      },
+  ], [
+      "docusaurus-plugin-remote-content",
+        {
+          name: "signal-to-service-horn-service",
+          sourceBaseUrl: "https://raw.githubusercontent.com/eclipse-sdv-blueprints/service-to-signal/main/components/horn-service-kuksa",
+          outDir: "docs/service-to-signal/components/horn-service-kuksa",
+          documents: ["README.md"],
+          requestConfig: { responseType: "arraybuffer" }
+        },
+  ], [
+        "docusaurus-plugin-remote-content",
+          {
+            name: "signal-to-service-horn-client",
+            sourceBaseUrl: "https://raw.githubusercontent.com/eclipse-sdv-blueprints/service-to-signal/main/components/horn-client",
+            outDir: "docs/service-to-signal/components/horn-client",
+            documents: ["README.md"],
+            requestConfig: { responseType: "arraybuffer" }
+          },
+  ], [
+        "docusaurus-plugin-remote-content",
+          {
+            name: "signal-to-service-actuator-provider",
+            sourceBaseUrl: "https://raw.githubusercontent.com/eclipse-sdv-blueprints/service-to-signal/main/components/actuator-provider",
+            outDir: "docs/service-to-signal/components/actuator-provider",
+            documents: ["README.md"],
+            requestConfig: { responseType: "arraybuffer" }
+          },
+  ], [
+    "docusaurus-plugin-remote-content",
+      {
+        name: "signal-to-service",
+        sourceBaseUrl: "https://raw.githubusercontent.com/eclipse-sdv-blueprints/service-to-signal/main",
+        outDir: "docs/service-to-signal",
+        documents: ["README.md"],
+        requestConfig: { responseType: "arraybuffer" }
+      },
+  ], [
+    "docusaurus-plugin-remote-content",
+      {
+        name: "signal-to-service-img",
+        sourceBaseUrl: "https://raw.githubusercontent.com/eclipse-sdv-blueprints/service-to-signal/main/img",
+        outDir: "docs/service-to-signal/img",
+        documents: ["overview.drawio.png"],
+        requestConfig: { responseType: "arraybuffer" }
       },
   ]],
   presets: [
@@ -132,6 +177,10 @@ const config = {
               {
                 label: 'Companion Application',
                 to: '/docs/companion-application/',
+              },
+              {
+                label: 'Service to Signal',
+                to: '/docs/service-to-signal/',
               },
               {
                 label: 'Fleet Management',

--- a/sidebars.js
+++ b/sidebars.js
@@ -41,6 +41,16 @@ const sidebars = {
           label: 'Fleet Management',
           link: { type: 'doc', id: 'fleet-management/introduction'},
           items: []
+        },
+        {
+          type: 'category',
+          label: 'Service to Signal',
+          link: { type: 'doc', id: 'service-to-signal/README'},
+          items: [
+            'service-to-signal/components/horn-service-kuksa/README',
+            'service-to-signal/components/horn-client/README',
+            'service-to-signal/components/actuator-provider/README'
+          ]
         }
       ]
     }


### PR DESCRIPTION
Adds the Service to Signal Blueprint to the documentation of the blueprints website. 
