### PR TITLE
update: fix preview URLs in PR workflow

### DIFF
--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -19,8 +19,8 @@ jobs:
     runs-on: ubuntu-latest
     env:
       PREVIEW_PATH: pr-preview/pr-${{ github.event.pull_request.number }}
-      PREVIEW_URL: https://eclipse-sdv-blueprints.github.io/pr-preview/pr-${{ github.event.pull_request.number }}/
-      DOCUSAURUS_URL: https://eclipse-sdv-blueprints.github.io
+      PREVIEW_URL: https://sdv-blueprints.eclipse.dev/pr-preview/pr-${{ github.event.pull_request.number }}/
+      DOCUSAURUS_URL: https://sdv-blueprints.eclipse.dev
       DOCUSAURUS_BASE_URL: /pr-preview/pr-${{ github.event.pull_request.number }}/
     steps:
       - name: Checkout


### PR DESCRIPTION
This pull request updates the preview deployment URLs in the GitHub Actions workflow configuration to use the new `sdv-blueprints.eclipse.dev` domain instead of the old `eclipse-sdv-blueprints.github.io` domain.

Deployment configuration updates:

* [`.github/workflows/preview.yml`](diffhunk://#diff-16e486445ce2ea5726b0c68b85147885aad9b8e9b6fe2dcee6f0369a8bba5eeeL22-R23): Changed the `PREVIEW_URL` and `DOCUSAURUS_URL` environment variables to use the new `sdv-blueprints.eclipse.dev` domain for preview deployments.